### PR TITLE
Add proxy server for ACI migration

### DIFF
--- a/Dockerfile.loki
+++ b/Dockerfile.loki
@@ -1,0 +1,13 @@
+# Dockerfile for devlogs Loki service
+#
+# Extends the official Loki image with the devlogs config baked in.
+# Needed for Azure Container Apps where config file mounts aren't available.
+#
+# Build:
+#   docker build -f Dockerfile.loki -t devlogs-loki .
+
+FROM grafana/loki:2.9.0
+
+COPY config/loki.yaml /etc/loki/local-config.yaml
+
+CMD ["-config.file=/etc/loki/local-config.yaml"]

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,0 +1,31 @@
+# Dockerfile for devlogs proxy service
+#
+# Build:
+#   docker build -f Dockerfile.proxy -t devlogs-proxy .
+#
+# Run:
+#   docker run -p 8080:8080 \
+#     -e COLLECTOR_URL=http://collector:8081 \
+#     -e LOKI_URL=http://loki:3100 \
+#     -e GRAFANA_URL=http://grafana:3000 \
+#     -e LOKI_ADMIN_TOKEN=<secret> \
+#     devlogs-proxy
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy package files
+COPY pyproject.toml README.md LICENSE ./
+COPY src/ ./src/
+
+# Install the package with proxy dependencies
+RUN pip install --no-cache-dir -e ".[proxy]"
+
+# Create non-root user for security
+RUN useradd -r -u 1000 proxy
+USER proxy
+
+EXPOSE 8080
+
+CMD ["python", "-m", "devlogs.proxy.server"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dev = [
   "pytest>=8.0.0",
   "pytest-asyncio>=0.23.0",
 ]
+proxy = [
+  "aiohttp>=3.9.0",
+]
 
 [project.scripts]
 devlogs = "devlogs.wrapper:main"

--- a/src/devlogs/proxy/server.py
+++ b/src/devlogs/proxy/server.py
@@ -18,6 +18,7 @@
 import hmac
 import logging
 import os
+import posixpath
 
 try:
     from aiohttp import web, ClientSession, ClientTimeout
@@ -32,7 +33,11 @@ GRAFANA_URL = os.environ.get("GRAFANA_URL", "http://localhost:3000").rstrip("/")
 LOKI_ADMIN_TOKEN = os.environ.get("LOKI_ADMIN_TOKEN", "")
 PORT = int(os.environ.get("PORT", "8080"))
 
-_SKIP_HEADERS = frozenset({"host", "content-length", "transfer-encoding"})
+_SKIP_HEADERS = frozenset({
+    "host", "content-length", "transfer-encoding",
+    "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto",
+    "forwarded", "x-real-ip", "x-original-url", "x-rewrite-url",
+})
 
 
 def _proxy_headers(request: web.Request) -> dict:
@@ -41,6 +46,9 @@ def _proxy_headers(request: web.Request) -> dict:
 
 def _build_target(base: str, strip_prefix: str, request: web.Request) -> str:
     path = request.path.removeprefix(strip_prefix) or "/"
+    path = posixpath.normpath(path)
+    if not path.startswith("/"):
+        path = "/" + path
     url = f"{base}{path}"
     if request.query_string:
         url += f"?{request.query_string}"
@@ -69,7 +77,8 @@ async def handle_ingest(request: web.Request) -> web.Response:
         allow_redirects=False,
     ) as resp:
         resp_body = await resp.read()
-        logger.info("%s /ingest → %s %d", request.method, target, resp.status)
+        log_url = target.split("?")[0]
+        logger.info("%s /ingest → %s %d", request.method, log_url, resp.status)
         content_type = resp.content_type or "application/octet-stream"
         return web.Response(status=resp.status, body=resp_body, content_type=content_type)
 

--- a/src/devlogs/proxy/server.py
+++ b/src/devlogs/proxy/server.py
@@ -1,0 +1,150 @@
+# Devlogs proxy server
+#
+# Routes external traffic to internal services:
+#   POST /ingest/*  →  Collector (token-in-URL auth, unchanged)
+#   GET  /query/*   →  Loki :3100 (Bearer token auth)
+#   GET  /grafana/* →  Grafana :3000 (Bearer token auth)
+#
+# Environment variables:
+#   COLLECTOR_URL     — Collector base URL (default: http://localhost:8081)
+#   LOKI_URL          — Loki base URL     (default: http://localhost:3100)
+#   GRAFANA_URL       — Grafana base URL  (default: http://localhost:3000)
+#   LOKI_ADMIN_TOKEN  — Bearer token for /query and /grafana routes
+#   PORT              — Port to listen on (default: 8080)
+#
+# Run:
+#   python -m devlogs.proxy.server
+
+import logging
+import os
+
+try:
+    from aiohttp import web, ClientSession, ClientTimeout
+except ImportError as e:
+    raise ImportError("aiohttp is required: pip install devlogs[proxy]") from e
+
+logger = logging.getLogger("devlogs.proxy")
+
+COLLECTOR_URL = os.environ.get("COLLECTOR_URL", "http://localhost:8081").rstrip("/")
+LOKI_URL = os.environ.get("LOKI_URL", "http://localhost:3100").rstrip("/")
+GRAFANA_URL = os.environ.get("GRAFANA_URL", "http://localhost:3000").rstrip("/")
+LOKI_ADMIN_TOKEN = os.environ.get("LOKI_ADMIN_TOKEN", "")
+PORT = int(os.environ.get("PORT", "8080"))
+
+_SKIP_HEADERS = frozenset({"host", "content-length", "transfer-encoding"})
+
+
+def _proxy_headers(request: web.Request) -> dict:
+    return {k: v for k, v in request.headers.items() if k.lower() not in _SKIP_HEADERS}
+
+
+def _build_target(base: str, strip_prefix: str, request: web.Request) -> str:
+    path = request.path.removeprefix(strip_prefix) or "/"
+    url = f"{base}{path}"
+    if request.query_string:
+        url += f"?{request.query_string}"
+    return url
+
+
+def _check_admin_token(request: web.Request) -> bool:
+    if not LOKI_ADMIN_TOKEN:
+        return False
+    return request.headers.get("Authorization", "") == f"Bearer {LOKI_ADMIN_TOKEN}"
+
+
+async def handle_ingest(request: web.Request) -> web.Response:
+    """Forward /ingest/* to Collector. Token in URL is passed through; Collector validates it."""
+    target = _build_target(COLLECTOR_URL, "/ingest", request)
+    body = await request.read()
+
+    async with request.app["session"].request(
+        method=request.method,
+        url=target,
+        headers=_proxy_headers(request),
+        data=body,
+        allow_redirects=False,
+    ) as resp:
+        resp_body = await resp.read()
+        logger.info("%s /ingest → %s %d", request.method, target, resp.status)
+        content_type = resp.content_type or "application/octet-stream"
+        return web.Response(status=resp.status, body=resp_body, content_type=content_type)
+
+
+async def handle_query(request: web.Request) -> web.Response:
+    """Validate Bearer token, strip /query prefix, forward to Loki."""
+    if not _check_admin_token(request):
+        return web.Response(status=401, text="Unauthorized")
+
+    target = _build_target(LOKI_URL, "/query", request)
+    body = await request.read()
+
+    async with request.app["session"].request(
+        method=request.method,
+        url=target,
+        headers=_proxy_headers(request),
+        data=body,
+        allow_redirects=False,
+    ) as resp:
+        resp_body = await resp.read()
+        logger.info("%s /query → %s %d", request.method, target, resp.status)
+        content_type = resp.content_type or "application/octet-stream"
+        return web.Response(status=resp.status, body=resp_body, content_type=content_type)
+
+
+async def handle_grafana(request: web.Request) -> web.Response:
+    """Validate Bearer token, strip /grafana prefix, forward to Grafana."""
+    if not _check_admin_token(request):
+        return web.Response(status=401, text="Unauthorized")
+
+    target = _build_target(GRAFANA_URL, "/grafana", request)
+    # Strip Authorization so Grafana uses its own session mechanism
+    headers = {k: v for k, v in _proxy_headers(request).items() if k.lower() != "authorization"}
+    body = await request.read()
+
+    async with request.app["session"].request(
+        method=request.method,
+        url=target,
+        headers=headers,
+        data=body,
+        allow_redirects=False,
+    ) as resp:
+        resp_body = await resp.read()
+        logger.info("%s /grafana → %s %d", request.method, target, resp.status)
+        content_type = resp.content_type or "application/octet-stream"
+        return web.Response(status=resp.status, body=resp_body, content_type=content_type)
+
+
+async def on_startup(app: web.Application) -> None:
+    timeout = ClientTimeout(total=30)
+    app["session"] = ClientSession(timeout=timeout)
+
+
+async def on_cleanup(app: web.Application) -> None:
+    await app["session"].close()
+
+
+def create_app() -> web.Application:
+    app = web.Application()
+    app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
+
+    app.router.add_route("*", "/ingest", handle_ingest)
+    app.router.add_route("*", "/ingest/{path_info:.*}", handle_ingest)
+    app.router.add_route("*", "/query", handle_query)
+    app.router.add_route("*", "/query/{path_info:.*}", handle_query)
+    app.router.add_route("*", "/grafana", handle_grafana)
+    app.router.add_route("*", "/grafana/{path_info:.*}", handle_grafana)
+
+    return app
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    if not LOKI_ADMIN_TOKEN:
+        logger.warning("LOKI_ADMIN_TOKEN is not set — /query and /grafana routes will reject all requests")
+
+    app = create_app()
+    web.run_app(app, host="0.0.0.0", port=PORT)

--- a/src/devlogs/proxy/server.py
+++ b/src/devlogs/proxy/server.py
@@ -15,6 +15,7 @@
 # Run:
 #   python -m devlogs.proxy.server
 
+import hmac
 import logging
 import os
 
@@ -49,7 +50,10 @@ def _build_target(base: str, strip_prefix: str, request: web.Request) -> str:
 def _check_admin_token(request: web.Request) -> bool:
     if not LOKI_ADMIN_TOKEN:
         return False
-    return request.headers.get("Authorization", "") == f"Bearer {LOKI_ADMIN_TOKEN}"
+    return hmac.compare_digest(
+        request.headers.get("Authorization", ""),
+        f"Bearer {LOKI_ADMIN_TOKEN}",
+    )
 
 
 async def handle_ingest(request: web.Request) -> web.Response:
@@ -124,7 +128,7 @@ async def on_cleanup(app: web.Application) -> None:
 
 
 def create_app() -> web.Application:
-    app = web.Application()
+    app = web.Application(client_max_size=1024 * 1024)  # 1 MB
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
 

--- a/tests/test_proxy_server.py
+++ b/tests/test_proxy_server.py
@@ -1,0 +1,261 @@
+# Tests for the devlogs proxy server
+#
+# Run: pytest tests/test_proxy_server.py -v
+# Requires: pip install devlogs[proxy] pytest-aiohttp
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock
+from aiohttp import web
+
+import devlogs.proxy.server as proxy_mod
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_mock_response(status: int, body: bytes = b"ok", content_type: str = "application/json"):
+    resp = AsyncMock()
+    resp.status = status
+    resp.content_type = content_type
+    resp.read = AsyncMock(return_value=body)
+    return resp
+
+
+def make_mock_session(response):
+    """Return a mock ClientSession whose .request() is an async context manager."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.request = MagicMock(return_value=cm)
+    session.close = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def admin_token(monkeypatch):
+    monkeypatch.setattr(proxy_mod, "LOKI_ADMIN_TOKEN", "test-secret")
+    return "test-secret"
+
+
+@pytest.fixture
+def collector_url(monkeypatch):
+    monkeypatch.setattr(proxy_mod, "COLLECTOR_URL", "http://collector:8081")
+
+
+@pytest.fixture
+def loki_url(monkeypatch):
+    monkeypatch.setattr(proxy_mod, "LOKI_URL", "http://loki:3100")
+
+
+@pytest.fixture
+def grafana_url(monkeypatch):
+    monkeypatch.setattr(proxy_mod, "GRAFANA_URL", "http://grafana:3000")
+
+
+@pytest_asyncio.fixture
+async def client(aiohttp_client, admin_token, collector_url, loki_url, grafana_url):
+    app = proxy_mod.create_app()
+    return await aiohttp_client(app)
+
+
+# ---------------------------------------------------------------------------
+# /ingest routing
+# ---------------------------------------------------------------------------
+
+class TestIngestRoute:
+    async def test_forwards_post_to_collector(self, client):
+        mock_resp = make_mock_response(202, b'{"status":"accepted"}')
+        client.app["session"] = make_mock_session(mock_resp)
+
+        resp = await client.post(
+            "/ingest",
+            data=b'{"application":"test","component":"c","message":"hi","level":"info"}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 202
+
+    async def test_strips_ingest_prefix_when_forwarding(self, client):
+        mock_resp = make_mock_response(202)
+        session = make_mock_session(mock_resp)
+        client.app["session"] = session
+
+        await client.post("/ingest", data=b"{}")
+        call_kwargs = session.request.call_args
+        forwarded_url = call_kwargs[1]["url"] if call_kwargs[1] else call_kwargs[0][1]
+        assert forwarded_url.startswith("http://collector:8081")
+        assert "/ingest" not in forwarded_url
+
+    async def test_preserves_query_string(self, client):
+        mock_resp = make_mock_response(202)
+        session = make_mock_session(mock_resp)
+        client.app["session"] = session
+
+        await client.post("/ingest?token=abc123", data=b"{}")
+        call_kwargs = session.request.call_args
+        forwarded_url = call_kwargs[1]["url"] if call_kwargs[1] else call_kwargs[0][1]
+        assert "token=abc123" in forwarded_url
+
+    async def test_no_auth_required(self, client):
+        """Write side has no proxy-level auth — Collector handles it."""
+        mock_resp = make_mock_response(202)
+        client.app["session"] = make_mock_session(mock_resp)
+
+        resp = await client.post("/ingest", data=b"{}")
+        # Should not be rejected by the proxy (202 or whatever the collector returns)
+        assert resp.status != 401
+
+    async def test_forwards_collector_error_status(self, client):
+        mock_resp = make_mock_response(401, b'{"code":"UNAUTHORIZED"}')
+        client.app["session"] = make_mock_session(mock_resp)
+
+        resp = await client.post("/ingest", data=b"{}")
+        assert resp.status == 401
+
+    async def test_nested_path_forwarded(self, client):
+        mock_resp = make_mock_response(202)
+        session = make_mock_session(mock_resp)
+        client.app["session"] = session
+
+        await client.post("/ingest/some/nested/path?token=abc", data=b"{}")
+        call_kwargs = session.request.call_args
+        forwarded_url = call_kwargs[1]["url"] if call_kwargs[1] else call_kwargs[0][1]
+        assert "some/nested/path" in forwarded_url
+        assert "token=abc" in forwarded_url
+
+
+# ---------------------------------------------------------------------------
+# /query routing
+# ---------------------------------------------------------------------------
+
+class TestQueryRoute:
+    async def test_rejects_missing_token(self, client):
+        resp = await client.get("/query/loki/api/v1/labels")
+        assert resp.status == 401
+
+    async def test_rejects_wrong_token(self, client):
+        resp = await client.get(
+            "/query/loki/api/v1/labels",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert resp.status == 401
+
+    async def test_accepts_correct_token(self, client, admin_token):
+        mock_resp = make_mock_response(200, b'{"data":[]}')
+        client.app["session"] = make_mock_session(mock_resp)
+
+        resp = await client.get(
+            "/query/loki/api/v1/labels",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status == 200
+
+    async def test_strips_query_prefix_when_forwarding(self, client, admin_token):
+        mock_resp = make_mock_response(200, b"{}")
+        session = make_mock_session(mock_resp)
+        client.app["session"] = session
+
+        await client.get(
+            "/query/loki/api/v1/labels",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        call_kwargs = session.request.call_args
+        forwarded_url = call_kwargs[1]["url"] if call_kwargs[1] else call_kwargs[0][1]
+        assert forwarded_url == "http://loki:3100/loki/api/v1/labels"
+
+    async def test_forwards_query_string_to_loki(self, client, admin_token):
+        mock_resp = make_mock_response(200, b"{}")
+        session = make_mock_session(mock_resp)
+        client.app["session"] = session
+
+        await client.get(
+            '/query/loki/api/v1/query_range?query={app="x"}&limit=50',
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        call_kwargs = session.request.call_args
+        forwarded_url = call_kwargs[1]["url"] if call_kwargs[1] else call_kwargs[0][1]
+        assert "query=" in forwarded_url
+        assert "limit=50" in forwarded_url
+
+
+# ---------------------------------------------------------------------------
+# /grafana routing
+# ---------------------------------------------------------------------------
+
+class TestGrafanaRoute:
+    async def test_rejects_missing_token(self, client):
+        resp = await client.get("/grafana/api/dashboards")
+        assert resp.status == 401
+
+    async def test_rejects_wrong_token(self, client):
+        resp = await client.get(
+            "/grafana/api/dashboards",
+            headers={"Authorization": "Bearer wrong"},
+        )
+        assert resp.status == 401
+
+    async def test_accepts_correct_token(self, client, admin_token):
+        mock_resp = make_mock_response(200, b"[]")
+        client.app["session"] = make_mock_session(mock_resp)
+
+        resp = await client.get(
+            "/grafana/api/dashboards",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status == 200
+
+    async def test_strips_authorization_before_forwarding_to_grafana(self, client, admin_token):
+        """Authorization header should not be forwarded — Grafana manages its own sessions."""
+        mock_resp = make_mock_response(200, b"[]")
+        session = make_mock_session(mock_resp)
+        client.app["session"] = session
+
+        await client.get(
+            "/grafana/api/dashboards",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        call_kwargs = session.request.call_args
+        forwarded_headers = call_kwargs[1].get("headers", {})
+        assert "authorization" not in {k.lower() for k in forwarded_headers}
+
+    async def test_strips_grafana_prefix_when_forwarding(self, client, admin_token):
+        mock_resp = make_mock_response(200, b"[]")
+        session = make_mock_session(mock_resp)
+        client.app["session"] = session
+
+        await client.get(
+            "/grafana/api/dashboards",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        call_kwargs = session.request.call_args
+        forwarded_url = call_kwargs[1]["url"] if call_kwargs[1] else call_kwargs[0][1]
+        assert forwarded_url == "http://grafana:3000/api/dashboards"
+
+
+# ---------------------------------------------------------------------------
+# Empty LOKI_ADMIN_TOKEN edge case
+# ---------------------------------------------------------------------------
+
+class TestNoAdminToken:
+    async def test_query_rejects_all_when_token_unset(self, aiohttp_client, monkeypatch,
+                                                       collector_url, loki_url, grafana_url):
+        monkeypatch.setattr(proxy_mod, "LOKI_ADMIN_TOKEN", "")
+        app = proxy_mod.create_app()
+        client = await aiohttp_client(app)
+
+        resp = await client.get("/query/loki/api/v1/labels",
+                                headers={"Authorization": "Bearer anything"})
+        assert resp.status == 401
+
+    async def test_grafana_rejects_all_when_token_unset(self, aiohttp_client, monkeypatch,
+                                                         collector_url, loki_url, grafana_url):
+        monkeypatch.setattr(proxy_mod, "LOKI_ADMIN_TOKEN", "")
+        app = proxy_mod.create_app()
+        client = await aiohttp_client(app)
+
+        resp = await client.get("/grafana/", headers={"Authorization": "Bearer anything"})
+        assert resp.status == 401


### PR DESCRIPTION
## Summary

- New `devlogs.proxy.server` — aiohttp HTTP proxy for the ACI deployment
- Routes `POST /ingest/*` to the Collector (token-in-URL auth, pass-through)
- Routes `GET /query/*` and `GET /grafana/*` to Loki/Grafana behind Bearer token auth
- `Dockerfile.proxy` for building the proxy container image
- `aiohttp>=3.9.0` added as optional `[proxy]` dependency
- 18 unit tests covering routing, prefix stripping, auth, and query string forwarding